### PR TITLE
wallet:fix GetAccountInfo map unlock

### DIFF
--- a/wallet/wallet/linkaccount.go
+++ b/wallet/wallet/linkaccount.go
@@ -701,8 +701,9 @@ func (la *LinkAccount) GetAccountInfo(tokenID *common.Address) (*types.GetAccoun
 	utxo := make([]types.UTXOAccount, count)
 	totalBalance := big.NewInt(0)
 	for i := uint64(0); i < uint64(count); i++ {
-		utxo[i] = types.UTXOAccount{Address: la.account.Keys[i].Address, Index: hexutil.Uint64(i), Balance: (*hexutil.Big)(la.getTokenBalanceBySubIndex(*tokenID, i))}
-		totalBalance.Add(totalBalance, la.getTokenBalanceBySubIndex(*tokenID, i))
+		ba := la.GetBalance(i, tokenID)
+		utxo[i] = types.UTXOAccount{Address: la.account.Keys[i].Address, Index: hexutil.Uint64(i), Balance: (*hexutil.Big)(ba)}
+		totalBalance.Add(totalBalance, ba)
 	}
 	ret.UTXOAccounts = utxo
 	eth := types.EthAccount{Address: la.account.EthAddress}


### PR DESCRIPTION
fix bug:
fatal error: concurrent map read and map write

goroutine 13261 [running]:
runtime.throw(0x13f1522, 0x21)
  /usr/local/go/src/runtime/panic.go:617 +0x72 fp=0xc011275320 sp=0xc0112752f0 pc=0x4f30d2
runtime.mapaccess2_fast64(0x12bff60, 0xc00018b950, 0x187, 0xc000131188, 0x1)
  /usr/local/go/src/runtime/map_fast64.go:61 +0x1c2 fp=0xc011275348 sp=0xc011275320 pc=0x4d6aa2
github.com/lianxiangcloud/linkchain/wallet/wallet.(*LinkAccount).getTokenBalanceBySubIndex(0xc0000ea2c0, 0x0, 0x0, 0xc000000000, 0x187, 0xc0127acae0)
  /home/jenkins/workspace/lkchain2.0.0/LKChain_AP_Build_linkchain_Stress_10.9.195.69/linkchain/wallet/wallet/linkaccount.go:154 +0x9e fp=0xc0112753d0 sp=0xc011275348 pc=0xbdc59e
github.com/lianxiangcloud/linkchain/wallet/wallet.(*LinkAccount).GetAccountInfo(0xc0000ea2c0, 0xc0137ae040, 0x5815cc, 0x1366a80, 0x1366a80)