### PR TITLE
wallet:fix GetLocalOutputs return err

### DIFF
--- a/wallet/wallet/linkaccount.go
+++ b/wallet/wallet/linkaccount.go
@@ -863,7 +863,9 @@ func (la *LinkAccount) GetLocalOutputs(ids []hexutil.Uint64) ([]types.UTXOOutput
 		var o *tctypes.UTXOOutputDetail
 		o, err = la.loadOutputDetail(uint64(nextid))
 		if err != nil {
+			la.Logger.Info("GetLocalOutputs", "id", nextid, "err", err)
 			if err == types.ErrOutputNotFound {
+				err = nil
 				continue
 			}
 			break


### PR DESCRIPTION
if la.loadOutputDetail return ErrOutputNotFound, we should set err nil