### PR TITLE
fix using wrong nonce when generate address

### DIFF
--- a/vm/evm/evm.go
+++ b/vm/evm/evm.go
@@ -532,11 +532,11 @@ func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64,
 	if !evm.CanTransfer(evm.StateDB, caller.Address(), common.EmptyAddress, value) {
 		return nil, common.EmptyAddress, gas, ErrInsufficientBalance
 	}
-	// Ensure there's no existing contract already at the designated address
+
 	nonce := evm.StateDB.GetNonce(caller.Address())
 	evm.StateDB.SetNonce(caller.Address(), nonce+1)
 
-	contractAddr = crypto.CreateAddress(caller.Address(), evm.Nonce, codeAndHash.code)
+	// Ensure there's no existing contract already at the designated address
 	contractHash := evm.StateDB.GetCodeHash(contractAddr)
 	if evm.StateDB.GetNonce(contractAddr) != 0 || (contractHash != common.EmptyHash && contractHash != emptyCodeHash) {
 		return nil, common.EmptyAddress, 0, ErrContractAddressCollision
@@ -605,7 +605,7 @@ func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64,
 func (evm *EVM) Create(c types.ContractRef, code []byte, gas uint64, value *big.Int) (ret []byte, contractAddr common.Address, leftOverGas uint64, err error) {
 
 	caller := c.(ContractRef)
-	contractAddr = crypto.CreateAddress(caller.Address(), evm.Nonce, code)
+	contractAddr = crypto.CreateAddress(caller.Address(), evm.StateDB.GetNonce(caller.Address()), code)
 
 	return evm.create(caller, &codeAndHash{code: code}, gas, value, contractAddr)
 }

--- a/vm/wasm/wasm.go
+++ b/vm/wasm/wasm.go
@@ -471,12 +471,12 @@ func (wasm *WASM) Create(c types.ContractRef, data []byte, gas uint64, value *bi
 		return nil, common.EmptyAddress, gas, fmt.Errorf("Invalid InitArgs Length for Contract Init Function")
 	}
 
-	// Ensure there's no existing contract already at the designated address
+	contractAddr = crypto.CreateAddress(caller.Address(), wasm.StateDB.GetNonce(caller.Address()), code)
+
 	nonce := wasm.StateDB.GetNonce(caller.Address())
 	wasm.StateDB.SetNonce(caller.Address(), nonce+1)
 
-	contractAddr = crypto.CreateAddress(caller.Address(), wasm.Nonce, code)
-
+	// Ensure there's no existing contract already at the designated address
 	contractHash := wasm.StateDB.GetCodeHash(contractAddr)
 	if wasm.StateDB.GetNonce(contractAddr) != 0 || (contractHash != common.EmptyHash && contractHash != emptyCodeHash) {
 		return nil, common.EmptyAddress, 0, vm.ErrContractAddressCollision


### PR DESCRIPTION
contract address now use caller's nonce instead of vm.Nonce