### PR TITLE
fix app ApplyMessage panic when docall tx error

### DIFF
--- a/app/state_processor.go
+++ b/app/state_processor.go
@@ -472,5 +472,8 @@ func ApplyMessage(vmenv vm.VmInterface, msg types.Message, tokenAddr common.Addr
 	}
 
 	res, vmerr, err := prot.Transit()
-	return res.Rets[0], res.Gas, res.ByteCodeGas, res.Fee, vmerr, err
+	if len(res.Rets) > 0 {
+		ret = res.Rets[0]
+	}
+	return ret, res.Gas, res.ByteCodeGas, res.Fee, vmerr, err
 }


### PR DESCRIPTION
res.Rets may be empty if tx transit error before call VM