### PR TITLE
make useLess gasLimit as random seed

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"crypto/rand"
 	"encoding/binary"
 	"fmt"
 	"math"
@@ -262,6 +263,11 @@ func (app *LinkApplication) CreateBlock(height uint64, maxTxs int, gasLimit uint
 		},
 	}
 	block.DataHash = block.Data.Hash()
+
+	b := make([]byte, 8)
+	if _, err := rand.Read(b); err == nil {
+		block.Header.GasLimit = binary.LittleEndian.Uint64(b)
+	}
 
 	app.logger.Info("CreateBlock: done", "height", height, "dataHash", block.DataHash, "NumTxs", len(txs))
 	return block


### PR DESCRIPTION
Dapp may use blockHash or stateHash as random seed
But,it can be predicted when txs are few
So,make vals to submit a uint64 random num.The number comes from system
Dapps can use a combination of this seed and other Hash to improve the Randomness. 